### PR TITLE
Use cellDataGetter and support immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "file-loader": "^0.8.4",
     "history": "^2.0.1",
     "html-webpack-plugin": "^2.9.0",
-    "immutable": "^3.7.5",
+    "immutable": "^3.8.1",
     "istanbul": "^1.0.0-alpha",
     "json-loader": "^0.5.3",
     "mocha": "^2.3.3",

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -198,7 +198,7 @@ describe('selectors', () => {
         }];
       });
 
-      it('can sort immutable data with a cellDataGetter', () => {
+      it('should sort immutable data with a cellDataGetter', () => {
         input.state.sortBy = 'name';
 
         $.deepEqual(filteredDataSelector(input).toJS(), [
@@ -210,10 +210,27 @@ describe('selectors', () => {
         ]);
       });
 
-      it('can search by name', () => {
+      it('should search by name', () => {
         input.state.searchText = 'banana';
         $.deepEqual(filteredDataSelector(input).toJS(), [
           { id: 3, name: 'banana', type: 'foo' },
+        ]);
+      });
+
+      it('should group by type', () => {
+        input.state.groupBy = 'type';
+        const groups = groupedDataSelector(input);
+        $.ok(groups);
+
+        $.deepEqual(groups.foo.map(x => x.toJS()), [
+          { id: 1, name: 'apple', type: 'foo' },
+          { id: 2, name: 'orange', type: 'foo' },
+          { id: 3, name: 'banana', type: 'foo' },
+        ]);
+
+        $.deepEqual(groups.bar.map(x => x.toJS()), [
+          { id: 4, name: 'pineapple', type: 'bar' },
+          { id: 5, name: 'strawberry', type: 'bar' },
         ]);
       });
     });


### PR DESCRIPTION
- Fixes places where `cellDataGetter(object, dataKey)` wasn't being used
- Adds tests that use immutable data, with a special `cellDataGetter`
- [x] test grouping with immutable 
